### PR TITLE
ARMv7-M: FPU Register optimization

### DIFF
--- a/Ports/ARM-Cortex-M/ARMv7-M/ARM/os_cpu.h
+++ b/Ports/ARM-Cortex-M/ARMv7-M/ARM/os_cpu.h
@@ -157,11 +157,6 @@ void  OS_CPU_SysTickInitFreq(CPU_INT32U   cpu_freq);
 void  OS_CPU_SysTickHandler (void);
 void  OS_CPU_PendSVHandler  (void);
 
-#if (OS_CPU_ARM_FP_EN > 0u)
-void  OS_CPU_FP_Reg_Push    (CPU_STK     *stkPtr);
-void  OS_CPU_FP_Reg_Pop     (CPU_STK     *stkPtr);
-#endif
-
 
 /*
 *********************************************************************************************************

--- a/Ports/ARM-Cortex-M/ARMv7-M/ARM/os_cpu_a.asm
+++ b/Ports/ARM-Cortex-M/ARMv7-M/ARM/os_cpu_a.asm
@@ -50,11 +50,6 @@
     EXPORT  OSIntCtxSw
     EXPORT  OS_CPU_PendSVHandler
 
-    IF {FPU} != "SoftVFP"
-    EXPORT  OS_CPU_FP_Reg_Push
-    EXPORT  OS_CPU_FP_Reg_Pop
-    ENDIF
-
 
 ;********************************************************************************************************
 ;                                               EQUATES
@@ -75,55 +70,6 @@ NVIC_PENDSVSET  EQU     0x10000000                              ; Value to trigg
 
     AREA CODE, CODE, READONLY
 
-
-;********************************************************************************************************
-;                                   FLOATING POINT REGISTERS PUSH
-;                             void  OS_CPU_FP_Reg_Push (CPU_STK  *stkPtr)
-;
-; Note(s) : 1) This function saves S16-S31 registers of the Floating Point Unit.
-;
-;           2) Pseudo-code is:
-;              a) Push remaining FPU regs S16-S31 on process stack;
-;              b) Update OSTCBCurPtr->StkPtr;
-;********************************************************************************************************
-
-    IF {FPU} != "SoftVFP"
-
-OS_CPU_FP_Reg_Push
-    MRS     R1, PSP                                             ; PSP is process stack pointer
-    CBZ     R1, OS_CPU_FP_nosave                                ; Skip FP register save the first time
-
-    VSTMDB  R0!, {S16-S31}
-    LDR     R1, =OSTCBCurPtr
-    LDR     R2, [R1]
-    STR     R0, [R2]
-OS_CPU_FP_nosave
-    BX      LR
-
-    ENDIF
-
-
-;********************************************************************************************************
-;                                   FLOATING POINT REGISTERS POP
-;                             void  OS_CPU_FP_Reg_Pop (CPU_STK  *stkPtr)
-;
-; Note(s) : 1) This function restores S16-S31 of the Floating Point Unit.
-;
-;           2) Pseudo-code is:
-;              a) Restore regs S16-S31 of new process stack;
-;              b) Update OSTCBHighRdyPtr->StkPtr pointer of new proces stack;
-;********************************************************************************************************
-
-    IF {FPU} != "SoftVFP"
-
-OS_CPU_FP_Reg_Pop
-    VLDMIA  R0!, {S16-S31}
-    LDR     R1, =OSTCBHighRdyPtr
-    LDR     R2, [R1]
-    STR     R0, [R2]
-    BX      LR
-
-    ENDIF
 
 
 ;********************************************************************************************************
@@ -177,6 +123,7 @@ OSStartHighRdy
 
     MRS     R0, CONTROL
     ORR     R0, R0, #2
+    BIC     R0, R0, #4                                          ; Clear FPCA bit to indicate FPU is not in use
     MSR     CONTROL, R0
     ISB                                                         ; Sync instruction stream
 
@@ -265,6 +212,13 @@ OS_CPU_PendSVHandler
     CPSIE   I
 
     MRS     R0, PSP                                             ; PSP is process stack pointer
+    IF {FPU} != "SoftVFP"
+                                                                ; Push high vfp registers if the task is using the FPU context
+    TST       R14, #0x10
+    IT        EQ
+    VSTMDBEQ  R0!, {S16-S31}
+    ENDIF
+
     STMFD   R0!, {R4-R11, R14}                                  ; Save remaining regs r4-11, R14 on process stack
 
     MOV32   R5, OSTCBCurPtr                                     ; OSTCBCurPtr->StkPtr = SP;
@@ -287,10 +241,22 @@ OS_CPU_PendSVHandler
     ORR     LR,  R4, #0x04                                      ; Ensure exception return uses process stack
     LDR     R0,  [R2]                                           ; R0 is new process SP; SP = OSTCBHighRdyPtr->StkPtr;
     LDMFD   R0!, {R4-R11, R14}                                  ; Restore r4-11, R14 from new process stack
+
+    IF {FPU} != "SoftVFP"
+                                                                ; Pop the high vfp registers if the next task is using the FPU context
+    TST       R14, #0x10
+    IT        EQ
+    VLDMIAEQ  R0!, {S16-S31}
+    ENDIF
+
     MSR     PSP, R0                                             ; Load PSP with new process SP
 
     MOV32   R2, #0                                              ; Restore BASEPRI priority level to 0
+    CPSID   I                                                   ; Cortex-M7 errata notice. See Note #5
     MSR     BASEPRI, R2
+    DSB
+    ISB
+    CPSIE   I
     BX      LR                                                  ; Exception return will restore remaining context
 
     ALIGN                                                       ; Removes warning[A1581W]: added <no_padbytes> of padding at <address>

--- a/Ports/ARM-Cortex-M/ARMv7-M/CCS/os_cpu.h
+++ b/Ports/ARM-Cortex-M/ARMv7-M/CCS/os_cpu.h
@@ -157,11 +157,6 @@ void  OS_CPU_SysTickInitFreq(CPU_INT32U   cpu_freq);
 void  OS_CPU_SysTickHandler (void);
 void  OS_CPU_PendSVHandler  (void);
 
-#if (OS_CPU_ARM_FP_EN > 0u)
-void  OS_CPU_FP_Reg_Push    (CPU_STK     *stkPtr);
-void  OS_CPU_FP_Reg_Pop     (CPU_STK     *stkPtr);
-#endif
-
 
 /*
 *********************************************************************************************************

--- a/Ports/ARM-Cortex-M/ARMv7-M/GNU/os_cpu.h
+++ b/Ports/ARM-Cortex-M/ARMv7-M/GNU/os_cpu.h
@@ -157,11 +157,6 @@ void  OS_CPU_SysTickInitFreq(CPU_INT32U   cpu_freq);
 void  OS_CPU_SysTickHandler (void);
 void  OS_CPU_PendSVHandler  (void);
 
-#if (OS_CPU_ARM_FP_EN > 0u)
-void  OS_CPU_FP_Reg_Push    (CPU_STK     *stkPtr);
-void  OS_CPU_FP_Reg_Pop     (CPU_STK     *stkPtr);
-#endif
-
 
 /*
 *********************************************************************************************************

--- a/Ports/ARM-Cortex-M/ARMv7-M/GNU/os_cpu_a.S
+++ b/Ports/ARM-Cortex-M/ARMv7-M/GNU/os_cpu_a.S
@@ -16,6 +16,9 @@
 @
 @                                             ARMv7-M Port
 @
+@ File      : os_cpu_a.asm
+@ Version   : V3.08.00
+@********************************************************************************************************
 @ For       : ARMv7-M Cortex-M
 @ Mode      : Thumb-2 ISA
 @ Toolchain : GNU C Compiler
@@ -46,10 +49,6 @@
     .global  OSIntCtxSw
     .global  OS_CPU_PendSVHandler
 
-#if (defined(__VFP_FP__) && !defined(__SOFTFP__))
-    .global  OS_CPU_FP_Reg_Push
-    .global  OS_CPU_FP_Reg_Pop
-#endif
 
 
 @********************************************************************************************************
@@ -70,56 +69,6 @@
    .align 2
    .thumb
    .syntax unified
-
-
-@********************************************************************************************************
-@                                   FLOATING POINT REGISTERS PUSH
-@                             void  OS_CPU_FP_Reg_Push (CPU_STK  *stkPtr)
-@
-@ Note(s) : 1) This function saves S16-S31 registers of the Floating Point Unit.
-@
-@           2) Pseudo-code is:
-@              a) Push remaining FPU regs S16-S31 on process stack;
-@              b) Update OSTCBCurPtr->StkPtr;
-@********************************************************************************************************
-
-#if (defined(__VFP_FP__) && !defined(__SOFTFP__))
-
-.thumb_func
-OS_CPU_FP_Reg_Push:
-    MRS     R1, PSP                                             @ PSP is process stack pointer
-    CBZ     R1, OS_CPU_FP_nosave                                @ Skip FP register save the first time
-
-    VSTMDB  R0!, {S16-S31}
-    LDR     R1, =OSTCBCurPtr
-    LDR     R2, [R1]
-    STR     R0, [R2]
-OS_CPU_FP_nosave:
-    BX      LR
-#endif
-
-
-@********************************************************************************************************
-@                                   FLOATING POINT REGISTERS POP
-@                             void  OS_CPU_FP_Reg_Pop (CPU_STK  *stkPtr)
-@
-@ Note(s) : 1) This function restores S16-S31 of the Floating Point Unit.
-@
-@           2) Pseudo-code is:
-@              a) Restore regs S16-S31 of new process stack;
-@              b) Update OSTCBHighRdyPtr->StkPtr pointer of new proces stack;
-@********************************************************************************************************
-
-#if (defined(__VFP_FP__) && !defined(__SOFTFP__))
-
-.thumb_func
-OS_CPU_FP_Reg_Pop:
-    VLDMIA  R0!, {S16-S31}
-    LDR     R1, =OSTCBHighRdyPtr
-    LDR     R2, [R1]
-    STR     R0, [R2]
-    BX      LR
-#endif
 
 
 @********************************************************************************************************
@@ -182,6 +131,7 @@ OSStartHighRdy:
 
     MRS     R0, CONTROL
     ORR     R0, R0, #2
+    BIC     R0, R0, #4                                          @ Clear FPCA bit to indicate FPU is not in use
     MSR     CONTROL, R0
     ISB                                                         @ Sync instruction stream
 
@@ -273,6 +223,13 @@ OS_CPU_PendSVHandler:
     CPSIE   I
 
     MRS     R0, PSP                                             @ PSP is process stack pointer
+#if (defined(__VFP_FP__) && !defined(__SOFTFP__))
+                                                                @ Push high vfp registers if the task is using the FPU context
+    TST       R14, #0x10
+    IT        EQ
+    VSTMDBEQ  R0!, {S16-S31}
+#endif
+
     STMFD   R0!, {R4-R11, R14}                                  @ Save remaining regs r4-11, R14 on process stack
 
     MOVW    R5, #:lower16:OSTCBCurPtr                           @ OSTCBCurPtr->StkPtr = SP;
@@ -299,10 +256,22 @@ OS_CPU_PendSVHandler:
     ORR     LR,  R4, #0x04                                      @ Ensure exception return uses process stack
     LDR     R0, [R2]                                            @ R0 is new process SP; SP = OSTCBHighRdyPtr->StkPtr;
     LDMFD   R0!, {R4-R11, R14}                                  @ Restore r4-11, R14 from new process stack
+
+#if (defined(__VFP_FP__) && !defined(__SOFTFP__))
+                                                                @ Pop the high vfp registers if the next task is using the FPU context
+    TST       R14, #0x10
+    IT        EQ
+    VLDMIAEQ  R0!, {S16-S31}
+#endif
+
     MSR     PSP, R0                                             @ Load PSP with new process SP
 
     MOV     R2, #0                                              @ Restore BASEPRI priority level to 0
+    CPSID   I                                                   @ Cortex-M7 errata notice. See Note #5
     MSR     BASEPRI, R2
+    DSB
+    ISB
+    CPSIE   I
     BX      LR                                                  @ Exception return will restore remaining context
 
 .end

--- a/Ports/ARM-Cortex-M/ARMv7-M/IAR/os_cpu.h
+++ b/Ports/ARM-Cortex-M/ARMv7-M/IAR/os_cpu.h
@@ -157,11 +157,6 @@ void  OS_CPU_SysTickInitFreq(CPU_INT32U   cpu_freq);
 void  OS_CPU_SysTickHandler (void);
 void  OS_CPU_PendSVHandler  (void);
 
-#if (OS_CPU_ARM_FP_EN > 0u)
-void  OS_CPU_FP_Reg_Push    (CPU_STK     *stkPtr);
-void  OS_CPU_FP_Reg_Pop     (CPU_STK     *stkPtr);
-#endif
-
 
 /*
 *********************************************************************************************************

--- a/Ports/ARM-Cortex-M/ARMv7-M/IAR/os_cpu_a.asm
+++ b/Ports/ARM-Cortex-M/ARMv7-M/IAR/os_cpu_a.asm
@@ -50,11 +50,6 @@
     PUBLIC  OSIntCtxSw
     PUBLIC  OS_CPU_PendSVHandler
 
-#ifdef __ARMVFP__
-    PUBLIC  OS_CPU_FP_Reg_Push
-    PUBLIC  OS_CPU_FP_Reg_Pop
-#endif
-
 
 ;********************************************************************************************************
 ;                                               EQUATES
@@ -73,51 +68,6 @@ NVIC_PENDSVSET  EQU     0x10000000                              ; Value to trigg
     RSEG CODE:CODE:NOROOT(2)
     THUMB
 
-
-;********************************************************************************************************
-;                                   FLOATING POINT REGISTERS PUSH
-;                             void  OS_CPU_FP_Reg_Push (CPU_STK  *stkPtr)
-;
-; Note(s) : 1) This function saves S16-S31 registers of the Floating Point Unit.
-;
-;           2) Pseudo-code is:
-;              a) Push remaining FPU regs S16-S31 on process stack;
-;              b) Update OSTCBCurPtr->StkPtr;
-;********************************************************************************************************
-
-#ifdef __ARMVFP__
-OS_CPU_FP_Reg_Push
-    MRS     R1, PSP                                             ; PSP is process stack pointer
-    CBZ     R1, OS_CPU_FP_nosave                                ; Skip FP register save the first time
-
-    VSTMDB  R0!, {S16-S31}
-    LDR     R1, =OSTCBCurPtr
-    LDR     R2, [R1]
-    STR     R0, [R2]
-OS_CPU_FP_nosave
-    BX      LR
-#endif
-
-
-;********************************************************************************************************
-;                                   FLOATING POINT REGISTERS POP
-;                             void  OS_CPU_FP_Reg_Pop (CPU_STK  *stkPtr)
-;
-; Note(s) : 1) This function restores S16-S31 of the Floating Point Unit.
-;
-;           2) Pseudo-code is:
-;              a) Restore regs S16-S31 of new process stack;
-;              b) Update OSTCBHighRdyPtr->StkPtr pointer of new proces stack;
-;********************************************************************************************************
-
-#ifdef __ARMVFP__
-OS_CPU_FP_Reg_Pop
-    VLDMIA  R0!, {S16-S31}
-    LDR     R1, =OSTCBHighRdyPtr
-    LDR     R2, [R1]
-    STR     R0, [R2]
-    BX      LR
-#endif
 
 
 ;********************************************************************************************************
@@ -171,6 +121,7 @@ OSStartHighRdy
 
     MRS     R0, CONTROL
     ORR     R0, R0, #2
+    BIC     R0, R0, #4                                          ; Clear FPCA bit to indicate FPU is not in use
     MSR     CONTROL, R0
     ISB                                                         ; Sync instruction stream
 
@@ -259,6 +210,13 @@ OS_CPU_PendSVHandler
     CPSIE   I
 
     MRS     R0, PSP                                             ; PSP is process stack pointer
+#ifdef __ARMVFP__
+                                                                ; Push high vfp registers if the task is using the FPU context
+    TST       R14, #0x10
+    IT        EQ
+    VSTMDBEQ  R0!, {S16-S31}
+#endif
+
     STMFD   R0!, {R4-R11, R14}                                  ; Save remaining regs r4-11, R14 on process stack
 
     MOV32   R5, OSTCBCurPtr                                     ; OSTCBCurPtr->StkPtr = SP;
@@ -281,10 +239,22 @@ OS_CPU_PendSVHandler
     ORR     LR,  R4, #0x04                                      ; Ensure exception return uses process stack
     LDR     R0,  [R2]                                           ; R0 is new process SP; SP = OSTCBHighRdyPtr->StkPtr;
     LDMFD   R0!, {R4-R11, R14}                                  ; Restore r4-11, R14 from new process stack
+
+#ifdef __ARMVFP__
+                                                                ; Pop the high vfp registers if the next task is using the FPU context
+    TST       R14, #0x10
+    IT        EQ
+    VLDMIAEQ  R0!, {S16-S31}
+#endif
+
     MSR     PSP, R0                                             ; Load PSP with new process SP
 
     MOV32   R2, #0                                              ; Restore BASEPRI priority level to 0
+    CPSID   I                                                   ; Cortex-M7 errata notice. See Note #5
     MSR     BASEPRI, R2
+    DSB
+    ISB
+    CPSIE   I
     BX      LR                                                  ; Exception return will restore remaining context
 
     END

--- a/Ports/ARM-Cortex-M/ARMv7-M/os_cpu_c.c
+++ b/Ports/ARM-Cortex-M/ARMv7-M/os_cpu_c.c
@@ -451,27 +451,6 @@ CPU_STK  *OSTaskStkInit (OS_TASK_PTR    p_task,
                                                                 /* Align the stack to 8-bytes.                          */
     p_stk = (CPU_STK *)((CPU_STK)(p_stk) & 0xFFFFFFF8u);
                                                                 /* Registers stacked as if auto-saved on exception      */
-#if (OS_CPU_ARM_FP_EN > 0u)                                     /* FPU auto-saved registers.                            */
-     --p_stk;
-    *(--p_stk) = (CPU_STK)0x02000000u;                          /* FPSCR                                                */
-                                                                /* Initialize S0-S15 floating point registers           */
-    *(--p_stk) = (CPU_STK)0x41700000u;                          /* S15                                                  */
-    *(--p_stk) = (CPU_STK)0x41600000u;                          /* S14                                                  */
-    *(--p_stk) = (CPU_STK)0x41500000u;                          /* S13                                                  */
-    *(--p_stk) = (CPU_STK)0x41400000u;                          /* S12                                                  */
-    *(--p_stk) = (CPU_STK)0x41300000u;                          /* S11                                                  */
-    *(--p_stk) = (CPU_STK)0x41200000u;                          /* S10                                                  */
-    *(--p_stk) = (CPU_STK)0x41100000u;                          /* S9                                                   */
-    *(--p_stk) = (CPU_STK)0x41000000u;                          /* S8                                                   */
-    *(--p_stk) = (CPU_STK)0x40E00000u;                          /* S7                                                   */
-    *(--p_stk) = (CPU_STK)0x40C00000u;                          /* S6                                                   */
-    *(--p_stk) = (CPU_STK)0x40A00000u;                          /* S5                                                   */
-    *(--p_stk) = (CPU_STK)0x40800000u;                          /* S4                                                   */
-    *(--p_stk) = (CPU_STK)0x40400000u;                          /* S3                                                   */
-    *(--p_stk) = (CPU_STK)0x40000000u;                          /* S2                                                   */
-    *(--p_stk) = (CPU_STK)0x3F800000u;                          /* S1                                                   */
-    *(--p_stk) = (CPU_STK)0x00000000u;                          /* S0                                                   */
-#endif
     *(--p_stk) = (CPU_STK)0x01000000u;                          /* xPSR                                                 */
     *(--p_stk) = (CPU_STK)p_task;                               /* Entry Point                                          */
     *(--p_stk) = (CPU_STK)OS_TaskReturn;                        /* R14 (LR)                                             */
@@ -480,12 +459,7 @@ CPU_STK  *OSTaskStkInit (OS_TASK_PTR    p_task,
     *(--p_stk) = (CPU_STK)0x02020202u;                          /* R2                                                   */
     *(--p_stk) = (CPU_STK)p_stk_limit;                          /* R1                                                   */
     *(--p_stk) = (CPU_STK)p_arg;                                /* R0 : argument                                        */
-
-#if (OS_CPU_ARM_FP_EN > 0u)
-    *(--p_stk) = (CPU_STK)0xFFFFFFEDuL;                         /* R14: EXEC_RETURN; See Note 5                         */
-#else
     *(--p_stk) = (CPU_STK)0xFFFFFFFDuL;                         /* R14: EXEC_RETURN; See Note 5                         */
-#endif
                                                                 /* Remaining registers saved on process stack           */
     *(--p_stk) = (CPU_STK)0x11111111uL;                         /* R11                                                  */
     *(--p_stk) = (CPU_STK)0x10101010uL;                         /* R10                                                  */
@@ -495,26 +469,6 @@ CPU_STK  *OSTaskStkInit (OS_TASK_PTR    p_task,
     *(--p_stk) = (CPU_STK)0x06060606uL;                         /* R6                                                   */
     *(--p_stk) = (CPU_STK)0x05050505uL;                         /* R5                                                   */
     *(--p_stk) = (CPU_STK)0x04040404uL;                         /* R4                                                   */
-
-#if (OS_CPU_ARM_FP_EN > 0u)
-                                                                /* Initialize S16-S31 floating point registers          */
-    *(--p_stk) = (CPU_STK)0x41F80000u;                          /* S31                                                  */
-    *(--p_stk) = (CPU_STK)0x41F00000u;                          /* S30                                                  */
-    *(--p_stk) = (CPU_STK)0x41E80000u;                          /* S29                                                  */
-    *(--p_stk) = (CPU_STK)0x41E00000u;                          /* S28                                                  */
-    *(--p_stk) = (CPU_STK)0x41D80000u;                          /* S27                                                  */
-    *(--p_stk) = (CPU_STK)0x41D00000u;                          /* S26                                                  */
-    *(--p_stk) = (CPU_STK)0x41C80000u;                          /* S25                                                  */
-    *(--p_stk) = (CPU_STK)0x41C00000u;                          /* S24                                                  */
-    *(--p_stk) = (CPU_STK)0x41B80000u;                          /* S23                                                  */
-    *(--p_stk) = (CPU_STK)0x41B00000u;                          /* S22                                                  */
-    *(--p_stk) = (CPU_STK)0x41A80000u;                          /* S21                                                  */
-    *(--p_stk) = (CPU_STK)0x41A00000u;                          /* S20                                                  */
-    *(--p_stk) = (CPU_STK)0x41980000u;                          /* S19                                                  */
-    *(--p_stk) = (CPU_STK)0x41900000u;                          /* S18                                                  */
-    *(--p_stk) = (CPU_STK)0x41880000u;                          /* S17                                                  */
-    *(--p_stk) = (CPU_STK)0x41800000u;                          /* S16                                                  */
-#endif
 
     return (p_stk);
 }
@@ -546,10 +500,6 @@ void  OSTaskSwHook (void)
 #endif
 #if (OS_CFG_TASK_STK_REDZONE_EN > 0u)
     CPU_BOOLEAN  stk_status;
-#endif
-
-#if (OS_CPU_ARM_FP_EN > 0u)
-    OS_CPU_FP_Reg_Push(OSTCBCurPtr->StkPtr);                    /* Push the FP registers of the current task.           */
 #endif
 
 #if OS_CFG_APP_HOOKS_EN > 0u
@@ -591,10 +541,6 @@ void  OSTaskSwHook (void)
     if (stk_status != OS_TRUE) {
         OSRedzoneHitHook(OSTCBCurPtr);
     }
-#endif
-
-#if (OS_CPU_ARM_FP_EN > 0u)
-    OS_CPU_FP_Reg_Pop(OSTCBHighRdyPtr->StkPtr);                 /* Pop the FP registers of the highest ready task.      */
 #endif
 }
 


### PR DESCRIPTION
Improvement to the ARMv7-M port: FPU registers only saved/restored on context switch if they've been used by the task.