### PR TITLE
New option: OS_CFG_OBJ_CREATED_CHK_EN

### DIFF
--- a/Cfg/Template/os_cfg.h
+++ b/Cfg/Template/os_cfg.h
@@ -36,6 +36,7 @@
 #define OS_CFG_DYN_TICK_EN                         0u           /* Enable (1) or Disable (0) the Dynamic Tick                            */
 #define OS_CFG_INVALID_OS_CALLS_CHK_EN             1u           /* Enable (1) or Disable (0) checks for invalid kernel calls             */
 #define OS_CFG_OBJ_TYPE_CHK_EN                     1u           /* Enable (1) or Disable (0) object type checking                        */
+#define OS_CFG_OBJ_CREATED_CHK_EN                  1u           /* Enable (1) or Disable (0) object created checks                       */
 #define OS_CFG_TS_EN                               0u           /* Enable (1) or Disable (0) time stamping                               */
 
 #define OS_CFG_PRIO_MAX                           64u           /* Defines the maximum number of task priorities (see OS_PRIO data type) */

--- a/Source/os.h
+++ b/Source/os.h
@@ -2144,6 +2144,15 @@ OS_TICK       OS_DynTickSet             (OS_TICK                ticks);
 #endif
 
 
+#ifndef OS_CFG_OBJ_CREATED_CHK_EN
+#error  "OS_CFG.H, Missing OS_CFG_OBJ_CREATED_CHK_EN: Allows you to include object created checks or not"
+#else
+    #if (OS_CFG_OBJ_CREATED_CHK_EN > 0u) && (OS_OBJ_TYPE_REQ == 0u)
+    #error "OS_CFG.H, OS_CFG_DBG_EN or OS_CFG_OBJ_TYPE_CHK_EN must be Enabled (1) to use object created checks."
+    #endif
+#endif
+
+
 #if     OS_CFG_PRIO_MAX < 8u
 #error  "OS_CFG.H, OS_CFG_PRIO_MAX must be >= 8"
 #endif

--- a/Source/os_dbg.c
+++ b/Source/os_dbg.c
@@ -106,6 +106,7 @@ CPU_INT16U  const  OSDbg_MutexSize             = 0u;
 #endif
 
 CPU_INT08U  const  OSDbg_ObjTypeChkEn          = OS_CFG_OBJ_TYPE_CHK_EN;
+CPU_INT08U  const  OSDbg_ObjCreatedChkEn       = OS_CFG_OBJ_CREATED_CHK_EN;
 
 
 CPU_INT16U  const  OSDbg_PendListSize          = sizeof(OS_PEND_LIST);
@@ -449,6 +450,7 @@ void  OS_Dbg_Init (void)
 #endif
 
     p_temp08 = (CPU_INT08U const *)&OSDbg_ObjTypeChkEn;
+    p_temp08 = (CPU_INT08U const *)&OSDbg_ObjCreatedChkEn;
 
     p_temp16 = (CPU_INT16U const *)&OSDbg_PendListSize;
     p_temp16 = (CPU_INT16U const *)&OSDbg_PendObjSize;

--- a/Source/os_flag.c
+++ b/Source/os_flag.c
@@ -96,11 +96,13 @@ void  OSFlagCreate (OS_FLAG_GRP  *p_grp,
 
     CPU_CRITICAL_ENTER();
 #if (OS_OBJ_TYPE_REQ > 0u)
+#if (OS_CFG_OBJ_CREATED_CHK_EN > 0u)
     if (p_grp->Type == OS_OBJ_TYPE_FLAG) {
         CPU_CRITICAL_EXIT();
         *p_err = OS_ERR_OBJ_CREATED;
         return;
     }
+#endif
     p_grp->Type    = OS_OBJ_TYPE_FLAG;                          /* Set to event flag group type                         */
 #endif
 #if (OS_CFG_DBG_EN > 0u)

--- a/Source/os_mem.c
+++ b/Source/os_mem.c
@@ -146,11 +146,13 @@ void  OSMemCreate (OS_MEM       *p_mem,
 
     CPU_CRITICAL_ENTER();
 #if (OS_OBJ_TYPE_REQ > 0u)
+#if (OS_CFG_OBJ_CREATED_CHK_EN > 0u)
     if (p_mem->Type == OS_OBJ_TYPE_MEM) {
         CPU_CRITICAL_EXIT();
         *p_err = OS_ERR_OBJ_CREATED;
         return;
     }
+#endif
     p_mem->Type        = OS_OBJ_TYPE_MEM;                       /* Set the type of object                               */
 #endif
 #if (OS_CFG_DBG_EN > 0u)

--- a/Source/os_mutex.c
+++ b/Source/os_mutex.c
@@ -95,11 +95,13 @@ void  OSMutexCreate (OS_MUTEX  *p_mutex,
 
     CPU_CRITICAL_ENTER();
 #if (OS_OBJ_TYPE_REQ > 0u)
+#if (OS_CFG_OBJ_CREATED_CHK_EN > 0u)
     if (p_mutex->Type == OS_OBJ_TYPE_MUTEX) {
         CPU_CRITICAL_EXIT();
         *p_err = OS_ERR_OBJ_CREATED;
         return;
     }
+#endif
     p_mutex->Type              =  OS_OBJ_TYPE_MUTEX;            /* Mark the data structure as a mutex                   */
 #endif
 #if (OS_CFG_DBG_EN > 0u)

--- a/Source/os_q.c
+++ b/Source/os_q.c
@@ -105,11 +105,13 @@ void  OSQCreate (OS_Q        *p_q,
 
     CPU_CRITICAL_ENTER();
 #if (OS_OBJ_TYPE_REQ > 0u)
+#if (OS_CFG_OBJ_CREATED_CHK_EN > 0u)
     if (p_q->Type == OS_OBJ_TYPE_Q) {
         CPU_CRITICAL_EXIT();
         *p_err = OS_ERR_OBJ_CREATED;
         return;
     }
+#endif
     p_q->Type    = OS_OBJ_TYPE_Q;                               /* Mark the data structure as a message queue           */
 #endif
 #if (OS_CFG_DBG_EN > 0u)

--- a/Source/os_sem.c
+++ b/Source/os_sem.c
@@ -100,11 +100,13 @@ void  OSSemCreate (OS_SEM      *p_sem,
 
     CPU_CRITICAL_ENTER();
 #if (OS_OBJ_TYPE_REQ > 0u)
+#if (OS_CFG_OBJ_CREATED_CHK_EN > 0u)
     if (p_sem->Type == OS_OBJ_TYPE_SEM) {
         CPU_CRITICAL_EXIT();
         *p_err = OS_ERR_OBJ_CREATED;
         return;
     }
+#endif
     p_sem->Type    = OS_OBJ_TYPE_SEM;                           /* Mark the data structure as a semaphore               */
 #endif
     p_sem->Ctr     = cnt;                                       /* Set semaphore value                                  */

--- a/Source/os_tmr.c
+++ b/Source/os_tmr.c
@@ -166,6 +166,7 @@ void  OSTmrCreate (OS_TMR               *p_tmr,
 
     p_tmr->State          = OS_TMR_STATE_STOPPED;               /* Initialize the timer fields                          */
 #if (OS_OBJ_TYPE_REQ > 0u)
+#if (OS_CFG_OBJ_CREATED_CHK_EN > 0u)
     if (p_tmr->Type == OS_OBJ_TYPE_TMR) {
         if (OSRunning == OS_STATE_OS_RUNNING) {
             OS_TmrUnlock();
@@ -173,6 +174,7 @@ void  OSTmrCreate (OS_TMR               *p_tmr,
         *p_err = OS_ERR_OBJ_CREATED;
         return;
     }
+#endif
     p_tmr->Type           = OS_OBJ_TYPE_TMR;
 #endif
 #if (OS_CFG_DBG_EN > 0u)


### PR DESCRIPTION
Added a compile-time configuration, OS_CFG_OBJ_CREATED_CHK_EN. This allows the user to disable the checks for double object creation, which can trigger a false positive during debug sessions.