### PR TITLE
docs: Fix a few typos

### DIFF
--- a/Ports/ARM-Cortex-M/ARMv6-M/os_cpu_c.c
+++ b/Ports/ARM-Cortex-M/ARMv6-M/os_cpu_c.c
@@ -279,8 +279,8 @@ void  OSTaskReturnHook (OS_TCB  *p_tcb)
 *                       prior to ARMV7 and to the A, R and M architecture profiles thereafter. Special considerations
 *                       associated with ARMV7M are discussed in section 2.3.3"
 *
-*                     (1) Even if the SP 8-byte aligment is not a requirement for the ARMv7M profile, the stack is aligned
-*                         to 8-byte boundaries to support legacy execution enviroments.
+*                     (1) Even if the SP 8-byte alignment is not a requirement for the ARMv7M profile, the stack is aligned
+*                         to 8-byte boundaries to support legacy execution environments.
 *
 *                 (c) Section 5.2.1.2 from the Procedure Call Standard for the ARM
 *                     architecture states :  "The stack must also conform to the following
@@ -288,7 +288,7 @@ void  OSTaskReturnHook (OS_TCB  *p_tcb)
 *
 *                     (1) SP mod 8 = 0. The stack must be double-word aligned"
 *
-*                 (d) From the ARM Technical Support Knowledge Base. 8 Byte stack aligment.
+*                 (d) From the ARM Technical Support Knowledge Base. 8 Byte stack alignment.
 *
 *                     "8 byte stack alignment is a requirement of the ARM Architecture Procedure
 *                      Call Standard [AAPCS]. This specifies that functions must maintain an 8 byte

--- a/Ports/ARM-Cortex-M/ARMv7-M/os_cpu_c.c
+++ b/Ports/ARM-Cortex-M/ARMv7-M/os_cpu_c.c
@@ -404,8 +404,8 @@ void  OSTaskReturnHook (OS_TCB  *p_tcb)
 *                       prior to ARMV7 and to the A, R and M architecture profiles thereafter. Special considerations
 *                       associated with ARMV7M are discussed in section 2.3.3"
 *
-*                     (1) Even if the SP 8-byte aligment is not a requirement for the ARMv7M profile, the stack is aligned
-*                         to 8-byte boundaries to support legacy execution enviroments.
+*                     (1) Even if the SP 8-byte alignment is not a requirement for the ARMv7M profile, the stack is aligned
+*                         to 8-byte boundaries to support legacy execution environments.
 *
 *                 (c) Section 5.2.1.2 from the Procedure Call Standard for the ARM
 *                     architecture states :  "The stack must also conform to the following
@@ -413,7 +413,7 @@ void  OSTaskReturnHook (OS_TCB  *p_tcb)
 *
 *                     (1) SP mod 8 = 0. The stack must be double-word aligned"
 *
-*                 (d) From the ARM Technical Support Knowledge Base. 8 Byte stack aligment.
+*                 (d) From the ARM Technical Support Knowledge Base. 8 Byte stack alignment.
 *
 *                     "8 byte stack alignment is a requirement of the ARM Architecture Procedure
 *                      Call Standard [AAPCS]. This specifies that functions must maintain an 8 byte

--- a/Ports/M14K/CodeSourcery/os_cpu_c.c
+++ b/Ports/M14K/CodeSourcery/os_cpu_c.c
@@ -146,7 +146,7 @@ void  OSTaskDelHook (OS_TCB *ptcb)
 *
 * Description: This function is called when a task returns without being properly deleted.
 *
-* Arguments  : ptcb   is a pointer to the task control block of the task that was accidently returned.
+* Arguments  : ptcb   is a pointer to the task control block of the task that was accidentally returned.
 *
 * Note(s)    : 1) Interrupts are disabled during this call.
 *********************************************************************************************************

--- a/Ports/Template/os_cpu.h
+++ b/Ports/Template/os_cpu.h
@@ -49,7 +49,7 @@ extern  "C" {
 *
 * Note(s): OS_TASK_SW()  invokes the task level context switch.
 *
-*          (1) On some processors, this corresponds to a call to OSCtxSw() which is an assemply language
+*          (1) On some processors, this corresponds to a call to OSCtxSw() which is an assembly language
 *              function that performs the context switch.
 *
 *          (2) On some processors, you need to simulate an interrupt using a 'sowfate interrupt' or a

--- a/Source/os_stat.c
+++ b/Source/os_stat.c
@@ -179,7 +179,7 @@ void  OSStatReset (OS_ERR  *p_err)
 *
 * Argument(s): p_err      is a pointer to a variable that will contain an error code returned by this function.
 *
-*                             OS_ERR_NONE              The call was successfu
+*                             OS_ERR_NONE              The call was successful
 *                             OS_ERR_OS_NOT_RUNNING    If uC/OS-III is not running yet
 *
 * Returns    : none

--- a/TLS/CCES/os_tls.c
+++ b/TLS/CCES/os_tls.c
@@ -180,7 +180,7 @@ OS_TLS  OS_TLS_GetValue (OS_TCB     *p_tcb,
 *                                                      OS_TLS_ID   id,
 *                                                      OS_TLS      value);
 *
-*                          you can specify a NULL pointer if you don't want to have a fucntion associated with a TLS
+*                          you can specify a NULL pointer if you don't want to have a function associated with a TLS
 *                          register.  A NULL pointer (i.e. no function associated with a TLS register) is the default
 *                          value placed in OS_TLS_DestructPtrTbl[].
 *

--- a/TLS/IAR/os_tls.c
+++ b/TLS/IAR/os_tls.c
@@ -225,7 +225,7 @@ OS_TLS  OS_TLS_GetValue (OS_TCB     *p_tcb,
 *                                                      OS_TLS_ID   id,
 *                                                      OS_TLS      value);
 *
-*                          you can specify a NULL pointer if you don't want to have a fucntion associated with a TLS
+*                          you can specify a NULL pointer if you don't want to have a function associated with a TLS
 *                          register.  A NULL pointer (i.e. no function associated with a TLS register) is the default
 *                          value placed in OS_TLS_DestructPtrTbl[].
 *
@@ -508,7 +508,7 @@ static  void  OS_TLS_LockCreate (void  **p_lock)
                   (CPU_CHAR *) 0,
                   (OS_ERR   *)&err);
 
-    if (err != OS_ERR_NONE) {                                     /* If the mutex create funtion fail?                */
+    if (err != OS_ERR_NONE) {                                     /* If the mutex create function fail?                */
         CPU_CRITICAL_ENTER();
                                                                   /* Return the OS_TLS_LOCK in front of the list      */
         p_tls_lock->NextPtr    = OS_TLS_LockPoolListPtr;

--- a/TLS/NewLib/os_tls.c
+++ b/TLS/NewLib/os_tls.c
@@ -209,7 +209,7 @@ OS_TLS  OS_TLS_GetValue (OS_TCB     *p_tcb,
 *                                                      OS_TLS_ID   id,
 *                                                      OS_TLS      value);
 *
-*                          you can specify a NULL pointer if you don't want to have a fucntion associated with a TLS
+*                          you can specify a NULL pointer if you don't want to have a function associated with a TLS
 *                          register.  A NULL pointer (i.e. no function associated with a TLS register) is the default
 *                          value placed in OS_TLS_DestructPtrTbl[].
 *

--- a/Template/bsp_os_dt.c
+++ b/Template/bsp_os_dt.c
@@ -188,7 +188,7 @@ OS_TICK  OS_DynTickGet (void)
     tmrcnt = /* $$$$ */;                                        /* Read current timer count.                            */
 
     if (/* $$$$ */) {                                           /* Check timer interrupt flag.                          */
-        return (TickDelta);                                     /* Counter Overflow has occured.                        */
+        return (TickDelta);                                     /* Counter Overflow has occurred.                        */
     }
 
     tmrcnt = TIMER_TO_OSTICK(tmrcnt);                           /* Otherwise, the value we read is valid.               */


### PR DESCRIPTION
There are small typos in:
- Ports/ARM-Cortex-M/ARMv6-M/os_cpu_c.c
- Ports/ARM-Cortex-M/ARMv7-M/os_cpu_c.c
- Ports/M14K/CodeSourcery/os_cpu_c.c
- Ports/Template/os_cpu.h
- Source/os_stat.c
- TLS/CCES/os_tls.c
- TLS/IAR/os_tls.c
- TLS/NewLib/os_tls.c
- Template/bsp_os_dt.c

Fixes:
- Should read `function` rather than `fucntion`.
- Should read `environments` rather than `enviroments`.
- Should read `alignment` rather than `aligment`.
- Should read `successful` rather than `successfu`.
- Should read `occurred` rather than `occured`.
- Should read `function` rather than `funtion`.
- Should read `assembly` rather than `assemply`.
- Should read `accidentally` rather than `accidently`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md